### PR TITLE
Update ping.js

### DIFF
--- a/scripts/ping.js
+++ b/scripts/ping.js
@@ -10,6 +10,6 @@
 // This script handles the following functions:
 //     Responds to the PING command with a PONG command.
 
-listen(/^PING :(.+)$/i, function(match) {
+listen(/^PING :(.+)/i, function(match) {
     irc.pong(match[1]);
 });


### PR DESCRIPTION
Fixed issue where server sends a ping right after the NICK command is sent, causing a timeout on connection, since the regex doesn't match it for some strange reason. Tested to make sure the ping/pong worked by letting the script run for quite a while.

The issue is when that ping comes in, it is in hex:
50 49 4e 47 20 3a 38 43 35 32 35 30 34 34 d

Notice the d by it self. Some how it's truncating the last byte which should be 0d - which would be a CR. This was tested on UnrealIRCd 3.x and 4.x.